### PR TITLE
switch to trusted publishing for npmjs.com

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,10 @@ jobs:
           node-version: '20.x'
           # registry-url is required for releasing packages
           registry-url: 'https://registry.npmjs.org'
+
+      - name: Install latest npm cli
+        run: npm install -g npm@latest
+
       # Skipping install since all assets are pre-built already
       # - run: npm install
  
@@ -25,8 +29,7 @@ jobs:
           ./yaml2json < ../schemas/v1.0/schema.yaml > ../schemas/v1.0/schema.json
 
       - name: Publish package
-        # --provenance enables the automatic generation of provenance statements
+        # --provenance enables the automatic generation of provenance statements (when using trusted publisher, this is automatically enabled and therefore optional)
         # --access public is only hard required for the initial release, but it doesn't hurt having it setup
+        # npm version >=11.5.1 required for trusted publisher
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This Pull Request updates the release workflow to utilize npmjs.com's [trusted publishing](https://docs.npmjs.com/trusted-publishers). 

As trusted publishing requires npm CLI version `>=11.5.1`, we manually install the latest version since the default installed npm version is insufficient.

This change eliminates the need for a static `NPM_TOKEN` secret, instead using short-lived OIDC identity tokens for authentication and package upload.

The necessary setup on npmjs.com has already been completed.

After this pull request is merged I will remove and invalidate the current static `NPM_TOKEN` secret.
<img width="812" height="247" alt="grafik" src="https://github.com/user-attachments/assets/75ded99e-a0e3-47de-b567-0d24c944acb2" />

